### PR TITLE
dnssecOps03-AlgorithmRollover: Fix link to RFC 6781 section 4.1.4 for algorithm rollover

### DIFF
--- a/inc/dnssec-ops/cases.yaml
+++ b/inc/dnssec-ops/cases.yaml
@@ -104,7 +104,7 @@ dnssecOps03-AlgorithmRollover:
   Description: |
     This test case verifies the RSP's ability to perform an algorithm rollover
     (as described in [Section 4.1.4 of
-    RFC 6781](https://www.rfc-editor.org/rfc/rfc6781.html#section-4.1.2)).
+    RFC 6781](https://www.rfc-editor.org/rfc/rfc6781.html#section-4.1.4)).
 
     The system will monitor the zone specified in the `dnssec.algorithmRolloverZone`
     input parameter. The domain may be present anywhere in the global DNS


### PR DESCRIPTION
Update the link in dnssecOps03-AlgorithmRolloverto point to the correct section of RFC 6781