### PR TITLE
Fix some copy and paste errors in the descriptions of some of the RDAP test cases.

### DIFF
--- a/inc/rdap/cases.yaml
+++ b/inc/rdap/cases.yaml
@@ -31,7 +31,7 @@ rdap-02:
     If the value of the `epp.hostModel` input parameter is `attributes`, this
     test will be skipped.
 
-    The client will send domain query requests for each nameserver in the
+    The client will send nameserver query requests for each nameserver in the
     `rdap.testNameservers` input parameter and validate the responses for
     conformance with the gTLD RDAP Profile.
 
@@ -47,7 +47,7 @@ rdap-03:
     This test validates the server's response to an entity query for a
     registrar.
 
-    The client will send domain query requests for each nameserver in the
+    The client will send entity query requests for each entity in the
     `rdap.testEntities` input parameter and validate the responses for
     conformance with the gTLD RDAP Profile.
 
@@ -61,9 +61,6 @@ rdap-04:
   Maturity: BETA
   Description: |
     This test validates the server's response to a help query.
-
-    If the value of the `epp.hostModel` input parameter is `attributes`, this
-    test will be skipped.
 
     The client will send a help query to each base URL specified in the
     `rdap.baseURLs` input parameter, and validate the responses for
@@ -96,7 +93,10 @@ rdap-06:
     This test validates that the server supports `HEAD` requests for
     nameservers.
 
-    The client will issue a `HEAD` request for each domain name in the
+    If the value of the `epp.hostModel` input parameter is `attributes`, this
+    test will be skipped.
+
+    The client will issue a `HEAD` request for each nameserver in the
     `rdap.testNameservers` input parameter and confirm that the server sends a
     response with (a) a status code of `200`, (b) a valid
     `access-control-allow-origin` header field, and (c) an empty body.
@@ -110,7 +110,7 @@ rdap-07:
   Description: |
     This test validates that the server supports `HEAD` requests for entities.
 
-    The client will issue a `HEAD` request for each domain name in the
+    The client will issue a `HEAD` request for each entity in the
     `rdap.testEntities` input parameter and confirm that the server sends a
     response with (a) a status code of `200`, (b) a valid
     `access-control-allow-origin` header field, and (c) an empty body.


### PR DESCRIPTION
closes #129