### PR TITLE
ignore -23202

### DIFF
--- a/tools/generate-rdapct-config.pl
+++ b/tools/generate-rdapct-config.pl
@@ -55,6 +55,8 @@ if (!exists($ARGV[0])) {
     -13006,
     -11703,
     -12205,
+
+    -23202, # to be removed once v3.1.0 of the RCT is integrated
 );
 
 #


### PR DESCRIPTION
Add -23202 to the `definitionIgnore` section to silence a [false positive](https://github.com/icann/rdap-conformance-tool/commit/70f660f853cc59d6baa9e4b0f35f64cbc34be3a0) that will be fixed in v3.1.0.