### PR TITLE
RCT config updates

### DIFF
--- a/tools/generate-rdapct-config.pl
+++ b/tools/generate-rdapct-config.pl
@@ -84,6 +84,8 @@ if (!exists($ARGV[0])) {
     -12314,
     -12315,
 
+
+    -12107, # false positive where a JSON body is required in error responses
     -12208, # false positive where an invalid LDH label is found in a nameserver
 );
 

--- a/tools/generate-rdapct-config.pl
+++ b/tools/generate-rdapct-config.pl
@@ -145,6 +145,16 @@ foreach my $code (@IGNORE) {
     # add code to definitionIgnore if not already present
     #
     push(@{$CONFIG->{definitionIgnore}}, $code) if (none { $_ == $code } @{$CONFIG->{definitionIgnore}});
+
+    #
+    # remove from definitionError if present
+    #
+    $CONFIG->{definitionError} = [ grep { $_->{code} != $code } @{$CONFIG->{definitionError}} ];
+
+    #
+    # remove from definitionError if present
+    #
+    $CONFIG->{definitionWarning} = [ grep { $_->{code} != $code } @{$CONFIG->{definitionWarning}} ];
 }
 
 if (q{RSP} eq $USAGE) {

--- a/tools/generate-rdapct-config.pl
+++ b/tools/generate-rdapct-config.pl
@@ -107,14 +107,43 @@ push(@IGNORE, @IGNORE_RSP) if (q{RSP} eq $USAGE);
 $CONFIG = mirror_json(TEMPLATE_URL);
 
 foreach my $code (@ERROR) {
+    #
+    # add code to definitionError if not already present
+    #
     push(@{$CONFIG->{definitionError}}, $code) if (none { $_->{code} == $code->{code} } @{$CONFIG->{definitionError}});
+
+    #
+    # remove from definitionWarning if present
+    #
+    $CONFIG->{definitionWarning} = [ grep { $_->{code} != $code->{code} } @{$CONFIG->{definitionWarning}} ];
+
+    #
+    # remove from definitionIgnore if present
+    #
+    $CONFIG->{definitionIgnore} = [ grep { $_ != $code->{code} } @{$CONFIG->{definitionIgnore}} ];
 }
 
 foreach my $code (@WARNING) {
+    #
+    # add code to definitionWarning if not already present
+    #
     push(@{$CONFIG->{definitionWarning}}, $code) if (none { $_->{code} == $code->{code} } @{$CONFIG->{definitionWarning}});
+
+    #
+    # remove from definitionError if present
+    #
+    $CONFIG->{definitionError} = [ grep { $_->{code} != $code->{code} } @{$CONFIG->{definitionError}} ];
+
+    #
+    # remove from definitionIgnore if present
+    #
+    $CONFIG->{definitionIgnore} = [ grep { $_ != $code->{code} } @{$CONFIG->{definitionIgnore}} ];
 }
 
 foreach my $code (@IGNORE) {
+    #
+    # add code to definitionIgnore if not already present
+    #
     push(@{$CONFIG->{definitionIgnore}}, $code) if (none { $_ == $code } @{$CONFIG->{definitionIgnore}});
 }
 


### PR DESCRIPTION
* add -12107 back
* if we put a code in `definitionWarning`, `definitionError` and `definitionIgnore`, remove it from the other sections.